### PR TITLE
fix(Enola): Check all websites similar to the given site flag

### DIFF
--- a/enola.go
+++ b/enola.go
@@ -64,16 +64,18 @@ func (s *Enola) List() map[string]Website { return s.Data }
 
 func (s *Enola) Check(username string) <-chan Result {
 	ch := make(chan Result)
-	data := s.Data
+	data := map[string]Website{}
+
 	if s.Site != "" {
-		for k, v := range data {
-			if strings.EqualFold(k, s.Site) {
-				data = map[string]Website{
-					k: v,
-				}
-				break
+		for k, v := range s.Data {
+			if strings.Contains(strings.ToLower(k), strings.Trim(strings.ToLower(s.Site), " ")) {
+				data[k] = v
 			}
 		}
+	}
+
+	if len(data) == 0 {
+		data = s.Data
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Previously Enola was checking if the website's name was equal to the given site flag, and if it found one, it just showed that one.
I changed the check part to show all websites containing the given site flag and all of them, not just one.
This PR is related to [issue #21 ](https://github.com/TheYahya/enola/issues/21).