### PR TITLE
refactor(enola): remove ioutil

### DIFF
--- a/enola.go
+++ b/enola.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -124,7 +124,7 @@ func (s *Enola) Check(username string) <-chan Result {
 					}
 					defer resp.Body.Close()
 
-					bodyBytes, err := ioutil.ReadAll(resp.Body)
+					bodyBytes, err := io.ReadAll(resp.Body)
 					if err != nil {
 						ch <- res
 						return


### PR DESCRIPTION
The "ioutil" has been deprecated since go 1.16. I replace it with the "io" package.