### PR TITLE
fix(enola): handle unsupported website

### DIFF
--- a/cmd/enola/find.go
+++ b/cmd/enola/find.go
@@ -19,9 +19,15 @@ func findAndShowResult(username, site string) {
 		panic(err)
 	}
 
+	resChan, err := sh.SetSite(site).Check(username)
+	if err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+
 	m := model{
 		list: list.New([]list.Item{}, NewDelegate(), 0, 0),
-		res:  sh.SetSite(site).Check(username),
+		res:  resChan,
 	}
 
 	m.list.Title = "Socials"

--- a/enola.go
+++ b/enola.go
@@ -62,7 +62,7 @@ func (s *Enola) SetSite(site string) *Enola {
 func (s *Enola) ListCount() int           { return len(s.Data) }
 func (s *Enola) List() map[string]Website { return s.Data }
 
-func (s *Enola) Check(username string) <-chan Result {
+func (s *Enola) Check(username string) (<-chan Result, error) {
 	ch := make(chan Result)
 	data := map[string]Website{}
 
@@ -71,6 +71,11 @@ func (s *Enola) Check(username string) <-chan Result {
 			if strings.Contains(strings.ToLower(k), strings.Trim(strings.ToLower(s.Site), " ")) {
 				data[k] = v
 			}
+		}
+
+		// if site is not found in the list
+		if len(data) == 0 {
+			return nil, errors.New(ErrSiteNotFound)
 		}
 	}
 
@@ -147,5 +152,5 @@ func (s *Enola) Check(username string) <-chan Result {
 		}
 	}()
 
-	return ch
+	return ch, nil
 }

--- a/error.go
+++ b/error.go
@@ -2,3 +2,4 @@ package enola
 
 const ErrNoDataFileExists = "err no data file exists"
 const ErrDataFileIsNotAValidJson = "err data file is not a valid json"
+const ErrSiteNotFound = "err requested site is not supported"


### PR DESCRIPTION
This fix handles a situation when a user requests a website that is not supported. Enola will prompt an error and exit.